### PR TITLE
New Auth cookies added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ test:
 .PHONY: audit
 audit:
 	go list -json -m all | nancy sleuth
-	
-.PHONY: build	
+
+.PHONY: build
 build:
 	go build ./...
+
+.PHONY: lint
+lint:
+	exit

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -13,4 +13,4 @@ inputs:
     path: dp-cookies
 
 run:
-  path: dp-cookies/ci/scripts/build.sh
+  path: dp-cookies/ci/scripts/lint.sh

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-cookies
+  make lint
+popd

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: latest
+    tag: 1.16.5
 
 inputs:
   - name: dp-cookies

--- a/cookies/collection.go
+++ b/cookies/collection.go
@@ -6,7 +6,9 @@ import (
 
 // SetCollection sets a cookie containing collection ID
 func SetCollection(w http.ResponseWriter, value, domain string) {
-	set(w, collectionIDCookieKey, value, domain, maxAgeBrowserSession)
+	path := "/"
+	httpOnly := false
+	set(w, collectionIDCookieKey, value, domain, path, maxAgeBrowserSession, http.SameSiteLaxMode, httpOnly)
 }
 
 // GetCollection reads collection_id cookie and returns it's value

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -51,17 +51,18 @@ func init() {
 	}
 }
 
-func set(w http.ResponseWriter, name, value, domain string, maxAge int) {
+func set(w http.ResponseWriter, name, value, domain, path string, maxAge int, sameSite http.SameSite, httpOnly bool) {
 	encodedValue := url.QueryEscape(value)
+
 	cookie := &http.Cookie{
 		Name:     name,
 		Value:    encodedValue,
-		Path:     "/",
+		Path:     path,
 		Domain:   domain,
-		HttpOnly: false,
+		HttpOnly: httpOnly,
 		Secure:   isRunningLocalDev,
 		MaxAge:   maxAge,
-		SameSite: http.SameSiteLaxMode,
+		SameSite: sameSite,
 	}
 	http.SetCookie(w, cookie)
 }

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -21,6 +21,12 @@ const (
 	// florenceCookieKey is the name of cookie set by Florence to store users access token
 	florenceCookieKey = "access_token"
 
+	// idCookieKey is the name of cookie set by Florence to store users id token used for refreshing an access_token
+	idCookieKey = "id_token"
+
+	// idCookieKey is the name of cookie set by Florence to store users refresh token used for refreshing an access_token
+	refreshCookieKey = "refresh_token"
+
 	// collectionIDCookieKey is the name of cookie set by Florence to store currenct active collection
 	collectionIDCookieKey = "collection"
 

--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -16,7 +16,7 @@ func TestUnitCookie(t *testing.T) {
 
 	Convey("Set sets correct cookie", t, func() {
 		rec := httptest.NewRecorder()
-		set(rec, testCookie, testValue, testDomain, 12)
+		set(rec, testCookie, testValue, testDomain, "/", 12, http.SameSiteLaxMode, false)
 		cookie := rec.Result().Cookies()[0]
 		So(cookie.Value, ShouldEqual, testValue)
 		So(cookie.Path, ShouldEqual, "/")

--- a/cookies/id_token.go
+++ b/cookies/id_token.go
@@ -1,0 +1,16 @@
+package cookies
+
+import (
+"net/http"
+)
+
+// SetIDToken sets a cookie containing users id token ("id_token")
+func SetIDToken(w http.ResponseWriter, idToken, domain string) {
+	set(w, idCookieKey, idToken, domain, maxAgeBrowserSession)
+}
+
+// GetIDToken reads id_token cookie and returns it's value
+func GetIDToken(req *http.Request) (string, error) {
+	return get(req, idCookieKey)
+}
+

--- a/cookies/id_token.go
+++ b/cookies/id_token.go
@@ -1,16 +1,17 @@
 package cookies
 
 import (
-"net/http"
+	"net/http"
 )
 
 // SetIDToken sets a cookie containing users id token ("id_token")
 func SetIDToken(w http.ResponseWriter, idToken, domain string) {
-	set(w, idCookieKey, idToken, domain, maxAgeBrowserSession)
+	path := "/"
+	httpOnly := false
+	set(w, idCookieKey, idToken, domain, path, maxAgeBrowserSession, http.SameSiteLaxMode, httpOnly)
 }
 
 // GetIDToken reads id_token cookie and returns it's value
 func GetIDToken(req *http.Request) (string, error) {
 	return get(req, idCookieKey)
 }
-

--- a/cookies/id_token_test.go
+++ b/cookies/id_token_test.go
@@ -1,11 +1,12 @@
 package cookies
 
 import (
-"net/http"
-"net/http/httptest"
-"testing"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
 
-. "github.com/smartystreets/goconvey/convey"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnitIDToken(t *testing.T) {
@@ -30,14 +31,21 @@ func TestUnitIDToken(t *testing.T) {
 
 	Convey("SetIDToken sets correct cookie", t, func() {
 		rec := httptest.NewRecorder()
+
+		correctCookie := &http.Cookie{
+			Name:     idCookieKey,
+			Value:    url.QueryEscape(testIDToken),
+			Path:     "/",
+			Domain:   testDomain,
+			HttpOnly: false,
+			Secure:   true,
+			MaxAge:   maxAgeBrowserSession,
+			SameSite: http.SameSiteLaxMode,
+			Raw:      "id_token=test-id-token; Path=/; Domain=www.test.com; Secure; SameSite=Lax",
+		}
+
 		SetIDToken(rec, testIDToken, testDomain)
 		cookie := rec.Result().Cookies()[0]
-		So(cookie.Value, ShouldEqual, testIDToken)
-		So(cookie.Path, ShouldEqual, "/")
-		So(cookie.Domain, ShouldEqual, testDomain)
-		So(cookie.MaxAge, ShouldEqual, maxAgeBrowserSession)
-		So(cookie.Secure, ShouldBeTrue)
-		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
+		So(cookie, ShouldResemble, correctCookie)
 	})
 }
-

--- a/cookies/id_token_test.go
+++ b/cookies/id_token_test.go
@@ -1,0 +1,43 @@
+package cookies
+
+import (
+"net/http"
+"net/http/httptest"
+"testing"
+
+. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitIDToken(t *testing.T) {
+
+	var testDomain = "www.test.com"
+	var testIDToken = "test-id-token"
+
+	Convey("GetIDToken", t, func() {
+		Convey("returns cookie value if value is set", func() {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.AddCookie(&http.Cookie{Name: idCookieKey, Value: testIDToken})
+			cookie, _ := GetIDToken(req)
+			So(cookie, ShouldEqual, testIDToken)
+		})
+
+		Convey("returns error if no cookie is set", func() {
+			req := httptest.NewRequest("GET", "/", nil)
+			_, err := GetIDToken(req)
+			So(err, ShouldNotBeNil)
+		})
+	})
+
+	Convey("SetIDToken sets correct cookie", t, func() {
+		rec := httptest.NewRecorder()
+		SetIDToken(rec, testIDToken, testDomain)
+		cookie := rec.Result().Cookies()[0]
+		So(cookie.Value, ShouldEqual, testIDToken)
+		So(cookie.Path, ShouldEqual, "/")
+		So(cookie.Domain, ShouldEqual, testDomain)
+		So(cookie.MaxAge, ShouldEqual, maxAgeBrowserSession)
+		So(cookie.Secure, ShouldBeTrue)
+		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
+	})
+}
+

--- a/cookies/locale.go
+++ b/cookies/locale.go
@@ -6,7 +6,9 @@ import (
 
 // SetLang sets a cookie containing locale code
 func SetLang(w http.ResponseWriter, lang, domain string) {
-	set(w, localeCookieKey, lang, domain, maxAgeOneYear)
+	path := "/"
+	httpOnly := false
+	set(w, localeCookieKey, lang, domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
 }
 
 // GetLang reads lang cookie and returns it's value

--- a/cookies/policy.go
+++ b/cookies/policy.go
@@ -36,7 +36,9 @@ func GetCookiePreferences(req *http.Request) PreferencesResponse {
 
 // SetPreferenceIsSet sets a cookie to record a user has set cookie preferences
 func SetPreferenceIsSet(w http.ResponseWriter, domain string) {
-	set(w, cookiesPreferencesSetCookieKey, "true", domain, maxAgeOneYear)
+	path := "/"
+	httpOnly := false
+	set(w, cookiesPreferencesSetCookieKey, "true", domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
 }
 
 func getPreferencesIsSet(req *http.Request) bool {
@@ -59,7 +61,9 @@ func SetPolicy(w http.ResponseWriter, policy Policy, domain string) {
 	if err != nil {
 		b, err = json.Marshal(defaultPolicy)
 	}
-	set(w, cookiesPolicyCookieKey, string(b), domain, maxAgeOneYear)
+	path := "/"
+	httpOnly := false
+	set(w, cookiesPolicyCookieKey, string(b), domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
 }
 
 func getPolicy(req *http.Request) Policy {

--- a/cookies/refresh_token.go
+++ b/cookies/refresh_token.go
@@ -1,12 +1,14 @@
 package cookies
 
 import (
-"net/http"
+	"net/http"
 )
 
 // SetRefreshToken sets a cookie containing users refresh token ("refresh_token")
 func SetRefreshToken(w http.ResponseWriter, refreshToken, domain string) {
-	set(w, refreshCookieKey, refreshToken, domain, maxAgeBrowserSession)
+	path := "/tokens/self"
+	httpOnly := true
+	set(w, refreshCookieKey, refreshToken, domain, path, maxAgeBrowserSession, http.SameSiteStrictMode, httpOnly)
 }
 
 // GetRefreshToken reads refresh_token cookie and returns it's value

--- a/cookies/refresh_token.go
+++ b/cookies/refresh_token.go
@@ -1,0 +1,15 @@
+package cookies
+
+import (
+"net/http"
+)
+
+// SetRefreshToken sets a cookie containing users refresh token ("refresh_token")
+func SetRefreshToken(w http.ResponseWriter, refreshToken, domain string) {
+	set(w, refreshCookieKey, refreshToken, domain, maxAgeBrowserSession)
+}
+
+// GetRefreshToken reads refresh_token cookie and returns it's value
+func GetRefreshToken(req *http.Request) (string, error) {
+	return get(req, refreshCookieKey)
+}

--- a/cookies/refresh_token_test.go
+++ b/cookies/refresh_token_test.go
@@ -1,9 +1,9 @@
 package cookies
 
-
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -30,15 +30,20 @@ func TestUnitRefreshToken(t *testing.T) {
 	})
 
 	Convey("SetRefreshToken sets correct cookie", t, func() {
+		correctCookie := &http.Cookie{
+			Name:     "refresh_token",
+			Value:    url.QueryEscape(testRefreshToken),
+			Path:     "/tokens/self",
+			Domain:   testDomain,
+			HttpOnly: true,
+			Secure:   true,
+			MaxAge:   maxAgeBrowserSession,
+			SameSite: http.SameSiteStrictMode,
+			Raw:      "refresh_token=test-refresh-token; Path=/tokens/self; Domain=www.test.com; HttpOnly; Secure; SameSite=Strict",
+		}
 		rec := httptest.NewRecorder()
 		SetRefreshToken(rec, testRefreshToken, testDomain)
 		cookie := rec.Result().Cookies()[0]
-		So(cookie.Value, ShouldEqual, testRefreshToken)
-		So(cookie.Path, ShouldEqual, "/")
-		So(cookie.Domain, ShouldEqual, testDomain)
-		So(cookie.MaxAge, ShouldEqual, maxAgeBrowserSession)
-		So(cookie.Secure, ShouldBeTrue)
-		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
+		So(cookie, ShouldResemble, correctCookie)
 	})
 }
-

--- a/cookies/refresh_token_test.go
+++ b/cookies/refresh_token_test.go
@@ -1,0 +1,44 @@
+package cookies
+
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitRefreshToken(t *testing.T) {
+
+	var testDomain = "www.test.com"
+	var testRefreshToken = "test-refresh-token"
+
+	Convey("GetRefreshToken", t, func() {
+		Convey("returns cookie value if value is set", func() {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.AddCookie(&http.Cookie{Name: refreshCookieKey, Value: testRefreshToken})
+			cookie, _ := GetRefreshToken(req)
+			So(cookie, ShouldEqual, testRefreshToken)
+		})
+
+		Convey("returns error if no cookie is set", func() {
+			req := httptest.NewRequest("GET", "/", nil)
+			_, err := GetRefreshToken(req)
+			So(err, ShouldNotBeNil)
+		})
+	})
+
+	Convey("SetRefreshToken sets correct cookie", t, func() {
+		rec := httptest.NewRecorder()
+		SetRefreshToken(rec, testRefreshToken, testDomain)
+		cookie := rec.Result().Cookies()[0]
+		So(cookie.Value, ShouldEqual, testRefreshToken)
+		So(cookie.Path, ShouldEqual, "/")
+		So(cookie.Domain, ShouldEqual, testDomain)
+		So(cookie.MaxAge, ShouldEqual, maxAgeBrowserSession)
+		So(cookie.Secure, ShouldBeTrue)
+		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
+	})
+}
+

--- a/cookies/usertoken.go
+++ b/cookies/usertoken.go
@@ -6,7 +6,9 @@ import (
 
 // SetUserAuthToken sets a cookie containing users auth token ("access token")
 func SetUserAuthToken(w http.ResponseWriter, userAuthToken, domain string) {
-	set(w, florenceCookieKey, userAuthToken, domain, maxAgeBrowserSession)
+	path := "/"
+	httpOnly := true
+	set(w, florenceCookieKey, userAuthToken, domain, path, maxAgeBrowserSession, http.SameSiteStrictMode, httpOnly)
 }
 
 // GetUserAuthToken reads access_token  cookie and returns it's value

--- a/cookies/usertoken_test.go
+++ b/cookies/usertoken_test.go
@@ -3,6 +3,7 @@ package cookies
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -30,13 +31,21 @@ func TestUnitUserToken(t *testing.T) {
 
 	Convey("SetUserAuthToken sets correct cookie", t, func() {
 		rec := httptest.NewRecorder()
+
+		correctCookie := &http.Cookie{
+			Name:     florenceCookieKey,
+			Value:    url.QueryEscape(testAccessToken),
+			Path:     "/",
+			Domain:   testDomain,
+			HttpOnly: true,
+			Secure:   true,
+			MaxAge:   maxAgeBrowserSession,
+			SameSite: http.SameSiteStrictMode,
+			Raw:      "access_token=test-access-token; Path=/; Domain=www.test.com; HttpOnly; Secure; SameSite=Strict",
+		}
+
 		SetUserAuthToken(rec, testAccessToken, testDomain)
 		cookie := rec.Result().Cookies()[0]
-		So(cookie.Value, ShouldEqual, testAccessToken)
-		So(cookie.Path, ShouldEqual, "/")
-		So(cookie.Domain, ShouldEqual, testDomain)
-		So(cookie.MaxAge, ShouldEqual, maxAgeBrowserSession)
-		So(cookie.Secure, ShouldBeTrue)
-		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
+		So(cookie, ShouldResemble, correctCookie)
 	})
 }


### PR DESCRIPTION
### What

New cookies added for the new OAuth Florence, dp-identity-api work
- `access_token` will continue to be the Authorisation token for users
- `refresh token` is used to refresh a users session if that session expires but the user is still active
- `id_token` is used by the backed auth service that dp-identity-api talks to when requesting a refresh of an access token. In addition, this token doesn't need to be secure and can be used on the frontend and even displayed on a UI in the future
- New lint job added (Makefile target doesn't actually do anything with it yet)
- CI yml files updates, they were using 'latest' but now use an exact go version as per a dev standards decision back in January
- Cookie tests for these tokens now check against an expected cookie, opposed to checking each individual attribute of a cookie

Note: The token names have been approved in team 404 slack.

In addition, we need the `refresh_token` and `acceess_token` cookies to be httpOnly (so that no JS can ever access it as otherwise it is vulnerable to XSS or CSRF attacks). To reduce the risk of us leaking the Refresh token we should only send it on requests that need it, as such the only endpoint to ever need it is the `tokens/self` as such this cookie will only be sent if a request is made to that endpoint. To achieve this the `set` cookie function had to be updated along with other `setX` cookie signatures.

### Who can review 

Anyone except me