### PR TITLE
Feature/add new cookies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,98 @@
+# This file was inspired by the golangci-lint one:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+linters-settings:
+  govet:
+    shadow: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 20
+  gocognit:
+    min-complexity: 40
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  misspell:
+    locale: UK
+  lll:
+    line-length: 140
+  gofmt:
+    simplify: false
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - wrapperFunc
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - hugeParam
+  revive:
+    rules:
+      # disabled as parameter names are useful for context even when unused, especially in interface implementations
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+    include:
+      - "**/*_test.go" # Specify test files to include
+  funlen:
+  # lines: 100
+  # statements: 100
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - dogsled
+    - errcheck
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - revive
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - nakedret
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - whitespace
+    - gocognit
+    - prealloc
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+    # Allow dot import in test files for goconvey
+    - path: _test.go
+      text: "dot-imports"
+      linters:
+        - revive
+      source: "github.com/smartystreets/goconvey/convey"
+  new: false

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ build:
 	go build ./...
 
 .PHONY: lint
-lint:
-	exit
+lint: ## Used in ci to run linters against Go code
+	golangci-lint run ./...

--- a/cookies/abtest_test.go
+++ b/cookies/abtest_test.go
@@ -132,7 +132,6 @@ func TestSetABTestCookieAspect(t *testing.T) {
 				So(cookieSetInResponse.SameSite, ShouldEqual, http.SameSiteLaxMode)
 			})
 		})
-
 	})
 }
 

--- a/cookies/collection_test.go
+++ b/cookies/collection_test.go
@@ -9,20 +9,19 @@ import (
 )
 
 func TestUnitCollection(t *testing.T) {
-
 	var testDomain = "www.ons.gov.uk"
 	var testCollectionID = "test-123456789"
 
 	Convey("GetUserAuthToken", t, func() {
 		Convey("returns cookie value if value is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: collectionIDCookieKey, Value: testCollectionID})
 			cookie, _ := GetCollection(req)
 			So(cookie, ShouldEqual, testCollectionID)
 		})
 
 		Convey("returns error if no cookie is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			_, err := GetCollection(req)
 			So(err, ShouldNotBeNil)
 		})

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -10,10 +10,20 @@ import (
 
 const (
 	// cookiesPolicyCookieKey is the  name of cookie used to determine the user selected cookie preferences
+	//
+	// Deprecated: cookiesPolicyCookieKey should only be used for maintaining legacy systems. Use onsCookiesPolicyCookieKey instead.
 	cookiesPolicyCookieKey = "cookies_policy"
 
+	// onsCookiePolicyCookieKey is the name of cookie used to determine the user selected ONS cookie preferences
+	onsCookiePolicyCookieKey = "ons_cookie_policy"
+
 	// cookiesPreferencesSetCookieKey is the name of cookie set once a user has made a choice preference decision
+	//
+	// Deprecated: cookiesPreferencesSetCookieKey should only be used for maintaining legacy systems. Use onsCookiesPreferencesSetCookieKey instead.
 	cookiesPreferencesSetCookieKey = "cookies_preferences_set"
+
+	// onsCookiePreferencesSetCookieKey is the name of cookie set once a user has made a choice preference decision
+	onsCookiePreferencesSetCookieKey = "ons_cookie_message_displayed"
 
 	// localeCookieKey is the name of cookie with user choosen language of website
 	localeCookieKey = "lang"

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -53,7 +53,7 @@ const (
 
 var isRunningLocalDev bool
 
-func init() {
+func init() { //nolint:gochecknoinits // init() is used for local/ci testing only
 	// Set a LIBRARY_TEST environment variable to TRUE when running locally or testing.
 	// Concourse test will run 'make debug' which includes setting this variable automatically.
 	// Note, this is required as we don't have the means to test secure cookies.
@@ -111,13 +111,4 @@ func get(req *http.Request, name string) (string, error) {
 		return "", fmt.Errorf("could not find cookie named '%v'", name)
 	}
 	return cookie.Value, nil
-}
-
-func update(req *http.Request, w http.ResponseWriter, name, value, domain, path string, maxAge int, sameSite http.SameSite, httpOnly bool) {
-	exisitingCookieValue, err := get(req, name)
-	if err != nil {
-		exisitingCookieValue = ""
-	}
-	newValue := exisitingCookieValue + value
-	set(w, name, newValue, domain, path, maxAge, sameSite, httpOnly)
 }

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -70,6 +71,23 @@ func set(w http.ResponseWriter, name, value, domain, path string, maxAge int, sa
 	cookie := &http.Cookie{
 		Name:     name,
 		Value:    encodedValue,
+		Path:     path,
+		Domain:   domain,
+		HttpOnly: httpOnly,
+		Secure:   isRunningLocalDev,
+		MaxAge:   maxAge,
+		SameSite: sameSite,
+	}
+	http.SetCookie(w, cookie)
+}
+
+// setUnencoded sets a cookie with the value not encoded
+func setUnencoded(w http.ResponseWriter, name, value, domain, path string, maxAge int, sameSite http.SameSite, httpOnly bool) {
+	convertedValue := strings.ReplaceAll(value, "\"", "'")
+
+	cookie := &http.Cookie{
+		Name:     name,
+		Value:    convertedValue,
 		Path:     path,
 		Domain:   domain,
 		HttpOnly: httpOnly,

--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestUnitCookie(t *testing.T) {
-
 	var testDomain = "www.test.com"
 	var testCookie = "test_cookie"
 	var testValue = "test-value"
@@ -26,6 +25,32 @@ func TestUnitCookie(t *testing.T) {
 		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
 	})
 
+	Convey("setUnencoded sets correct cookie", t, func() {
+		rec := httptest.NewRecorder()
+		setCookieWithUnencodedValue(rec, testCookie, testValue, testDomain, "/", 12, http.SameSiteLaxMode, false)
+		cookie := rec.Result().Cookies()[0]
+		So(cookie.Value, ShouldEqual, testValue)
+		So(cookie.Path, ShouldEqual, "/")
+		So(cookie.Domain, ShouldEqual, testDomain)
+		So(cookie.MaxAge, ShouldEqual, 12)
+		So(cookie.Secure, ShouldBeTrue)
+		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
+	})
+
+	Convey("setUnencoded strips quotes from cookie value", t, func() {
+		rec := httptest.NewRecorder()
+		setCookieWithUnencodedValue(rec, testCookie, "{'testValue':true,'otherValue':false}", testDomain, "/", 12, http.SameSiteLaxMode, false)
+		cookie := rec.Result().Cookies()[0]
+		So(cookie.Value, ShouldEqual, "{'testValue':true,'otherValue':false}")
+		So(cookie.Path, ShouldEqual, "/")
+		So(cookie.Domain, ShouldEqual, testDomain)
+		So(cookie.MaxAge, ShouldEqual, 12)
+		So(cookie.Secure, ShouldBeTrue)
+		So(cookie.SameSite, ShouldEqual, http.SameSiteLaxMode)
+		header := rec.Header().Get("Set-Cookie")
+		So(header, ShouldEqual, "test_cookie={'testValue':true,'otherValue':false}; Path=/; Domain=www.test.com; Max-Age=12; Secure; SameSite=Lax")
+	})
+
 	Convey("Get", t, func() {
 		Convey("returns cookie value if value is set", func() {
 			req := httptest.NewRequest("GET", "/", nil)
@@ -40,5 +65,4 @@ func TestUnitCookie(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 	})
-
 }

--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -53,14 +53,14 @@ func TestUnitCookie(t *testing.T) {
 
 	Convey("Get", t, func() {
 		Convey("returns cookie value if value is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: "test-cookie", Value: "test-value"})
 			cookie, _ := get(req, "test-cookie")
 			So(cookie, ShouldEqual, "test-value")
 		})
 
 		Convey("returns error if no cookie is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			_, err := GetLang(req)
 			So(err, ShouldNotBeNil)
 		})

--- a/cookies/id_token_test.go
+++ b/cookies/id_token_test.go
@@ -10,20 +10,19 @@ import (
 )
 
 func TestUnitIDToken(t *testing.T) {
-
 	var testDomain = "www.test.com"
 	var testIDToken = "test-id-token"
 
 	Convey("GetIDToken", t, func() {
 		Convey("returns cookie value if value is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: idCookieKey, Value: testIDToken})
 			cookie, _ := GetIDToken(req)
 			So(cookie, ShouldEqual, testIDToken)
 		})
 
 		Convey("returns error if no cookie is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			_, err := GetIDToken(req)
 			So(err, ShouldNotBeNil)
 		})

--- a/cookies/locale_test.go
+++ b/cookies/locale_test.go
@@ -9,20 +9,19 @@ import (
 )
 
 func TestUnitLocale(t *testing.T) {
-
 	var testDomain = "www.test.com"
 	var testLang = "en"
 
 	Convey("GetLang", t, func() {
 		Convey("returns cookie value if value is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: localeCookieKey, Value: testLang})
 			cookie, _ := GetLang(req)
 			So(cookie, ShouldEqual, testLang)
 		})
 
 		Convey("returns error if no cookie is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			_, err := GetLang(req)
 			So(err, ShouldNotBeNil)
 		})

--- a/cookies/policy.go
+++ b/cookies/policy.go
@@ -14,7 +14,13 @@ type PreferencesResponse struct {
 	Policy          Policy
 }
 
-// Policy is cookie policy setting choosen by a user
+// ONSPreferencesResponse is a combination of ONS cookie policy and whether they have be set by user
+type ONSPreferencesResponse struct {
+	IsPreferenceSet bool
+	Policy          ONSPolicy
+}
+
+// Policy is cookie policy setting chosen by a user
 type Policy struct {
 	Essential bool `json:"essential"`
 	Usage     bool `json:"usage"`
@@ -25,11 +31,36 @@ var defaultPolicy = Policy{
 	Usage:     false,
 }
 
+// ONSPolicy is the ONS cookie policy setting chosen by a user
+type ONSPolicy struct {
+	Essential bool `json:"essential"`
+	Settings  bool `json:"settings"`
+	Usage     bool `json:"usage"`
+	Campaigns bool `json:"campaigns"`
+}
+
+var defaultONSPolicy = ONSPolicy{
+	Essential: true,
+	Settings:  false,
+	Usage:     false,
+	Campaigns: false,
+}
+
 // GetCookiePreferences returns a struct with all cookie preferences
 func GetCookiePreferences(req *http.Request) PreferencesResponse {
 	isPreferenceSet := getPreferencesIsSet(req)
 	cookiePolicy := getPolicy(req)
 	return PreferencesResponse{
+		IsPreferenceSet: isPreferenceSet,
+		Policy:          cookiePolicy,
+	}
+}
+
+// GetCookiePreferences returns a struct with all cookie preferences
+func GetONSCookiePreferences(req *http.Request) ONSPreferencesResponse {
+	isPreferenceSet := getONSPreferencesIsSet(req)
+	cookiePolicy := getONSPolicy(req)
+	return ONSPreferencesResponse{
 		IsPreferenceSet: isPreferenceSet,
 		Policy:          cookiePolicy,
 	}
@@ -56,11 +87,32 @@ func getPreferencesIsSet(req *http.Request) bool {
 	return cookieIsPreferenceSet
 }
 
+// SetONSPreferenceIsSet sets the ONS cookie to record whether the user has set cookie preferences
+func SetONSPreferenceIsSet(w http.ResponseWriter, domain string) {
+	path := "/"
+	httpOnly := false
+	set(w, onsCookiePreferencesSetCookieKey, "true", domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
+}
+
+func getONSPreferencesIsSet(req *http.Request) bool {
+	cookiesPreferencesSetCookie, err := req.Cookie(onsCookiePreferencesSetCookieKey)
+	if err != nil {
+		return false
+	}
+
+	cookieIsPreferenceSet, err := strconv.ParseBool(cookiesPreferencesSetCookie.Value)
+	if err != nil {
+		return false
+	}
+
+	return cookieIsPreferenceSet
+}
+
 // SetPolicy sets a cookie with the users preferences, or sets default preferences on error
 func SetPolicy(w http.ResponseWriter, policy Policy, domain string) {
 	b, err := json.Marshal(policy)
 	if err != nil {
-		b, err = json.Marshal(defaultPolicy)
+		b, _ = json.Marshal(defaultPolicy)
 	}
 	path := "/"
 	httpOnly := false
@@ -75,7 +127,7 @@ func SetONSPolicy(w http.ResponseWriter, policy ONSPolicy, domain string) {
 	}
 	path := "/"
 	httpOnly := false
-	setCookieWithUnencodedValue(w, onsCookiePolicyCookieKey, string(b), domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
+	setUnencoded(w, onsCookiePolicyCookieKey, string(b), domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
 }
 
 func getPolicy(req *http.Request) Policy {

--- a/cookies/policy.go
+++ b/cookies/policy.go
@@ -67,6 +67,8 @@ func GetONSCookiePreferences(req *http.Request) ONSPreferencesResponse {
 }
 
 // SetPreferenceIsSet sets a cookie to record a user has set cookie preferences
+//
+// Deprecated: Use SetONSPreferenceIsSet instead
 func SetPreferenceIsSet(w http.ResponseWriter, domain string) {
 	path := "/"
 	httpOnly := false
@@ -109,6 +111,8 @@ func getONSPreferencesIsSet(req *http.Request) bool {
 }
 
 // SetPolicy sets a cookie with the users preferences, or sets default preferences on error
+//
+// Deprecated: Use SetONSPolicy instead
 func SetPolicy(w http.ResponseWriter, policy Policy, domain string) {
 	b, err := json.Marshal(policy)
 	if err != nil {

--- a/cookies/policy.go
+++ b/cookies/policy.go
@@ -131,7 +131,7 @@ func SetONSPolicy(w http.ResponseWriter, policy ONSPolicy, domain string) {
 	}
 	path := "/"
 	httpOnly := false
-	setUnencoded(w, onsCookiePolicyCookieKey, string(b), domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
+	setCookieWithUnencodedValue(w, onsCookiePolicyCookieKey, string(b), domain, path, maxAgeOneYear, http.SameSiteLaxMode, httpOnly)
 }
 
 func getPolicy(req *http.Request) Policy {

--- a/cookies/policy.go
+++ b/cookies/policy.go
@@ -146,7 +146,11 @@ func getPolicy(req *http.Request) Policy {
 	}
 
 	cookiePolicy := Policy{}
-	json.Unmarshal([]byte(unescapedPolicy), &cookiePolicy)
+	jErr := json.Unmarshal([]byte(unescapedPolicy), &cookiePolicy)
+	if jErr != nil {
+		return defaultPolicy
+	}
+
 	return cookiePolicy
 }
 
@@ -165,6 +169,10 @@ func getONSPolicy(req *http.Request) ONSPolicy {
 	validJSONPolicy := strings.ReplaceAll(unescapedPolicy, "'", "\"")
 
 	cookiePolicy := ONSPolicy{}
-	json.Unmarshal([]byte(validJSONPolicy), &cookiePolicy)
+	jErr := json.Unmarshal([]byte(validJSONPolicy), &cookiePolicy)
+	if jErr != nil {
+		return defaultONSPolicy
+	}
+
 	return cookiePolicy
 }

--- a/cookies/policy_test.go
+++ b/cookies/policy_test.go
@@ -10,13 +10,12 @@ import (
 )
 
 func TestUnitPolicy(t *testing.T) {
-
 	var testDomain = "www.test.com"
 	var testEncodedCookieValue = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D"
 
 	Convey("GetCookiePreferences", t, func() {
 		Convey("returns false for prefrences set if cookie isn't set, and default policy if no cookies set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			cookie := GetCookiePreferences(req)
 			So(cookie, ShouldResemble, PreferencesResponse{
 				IsPreferenceSet: false,
@@ -28,7 +27,7 @@ func TestUnitPolicy(t *testing.T) {
 		})
 
 		Convey("returns true for prefrences set if cookie is set, and default policy if no cookies set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: cookiesPreferencesSetCookieKey, Value: "true"})
 			cookie := GetCookiePreferences(req)
 			So(cookie, ShouldResemble, PreferencesResponse{
@@ -41,7 +40,7 @@ func TestUnitPolicy(t *testing.T) {
 		})
 
 		Convey("returns true for prefrences set if cookie is set, and correct policy if cookie set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: cookiesPreferencesSetCookieKey, Value: "true"})
 			req.AddCookie(&http.Cookie{Name: cookiesPolicyCookieKey, Value: testEncodedCookieValue})
 			cookie := GetCookiePreferences(req)
@@ -83,7 +82,7 @@ func TestUnitPolicy(t *testing.T) {
 func TestUnitONSPolicy(t *testing.T) {
 	Convey("GetONSCookiePreferences", t, func() {
 		Convey("returns false for preferences set if cookie isn't set, and default policy if no cookies set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			cookie := GetONSCookiePreferences(req)
 			So(cookie, ShouldResemble, ONSPreferencesResponse{
 				IsPreferenceSet: false,
@@ -97,7 +96,7 @@ func TestUnitONSPolicy(t *testing.T) {
 		})
 
 		Convey("returns true for preferences set if cookie is set, and default policy if no cookies set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: onsCookiePreferencesSetCookieKey, Value: "true"})
 			cookie := GetONSCookiePreferences(req)
 			So(cookie, ShouldResemble, ONSPreferencesResponse{
@@ -171,7 +170,7 @@ func TestUnitONSPolicy(t *testing.T) {
 		Convey("returns true for preference set if cookie is set, and matches preferences", func() {
 			for _, t := range tc {
 				Convey(fmt.Sprintf("when %s", t.scenario), func() {
-					req := httptest.NewRequest("GET", "/", nil)
+					req := httptest.NewRequest("GET", "/", http.NoBody)
 					req.AddCookie(&http.Cookie{Name: onsCookiePreferencesSetCookieKey, Value: "true"})
 					req.AddCookie(&http.Cookie{Name: onsCookiePolicyCookieKey, Value: t.given})
 					cookie := GetONSCookiePreferences(req)

--- a/cookies/refresh_token_test.go
+++ b/cookies/refresh_token_test.go
@@ -10,20 +10,19 @@ import (
 )
 
 func TestUnitRefreshToken(t *testing.T) {
-
 	var testDomain = "www.test.com"
 	var testRefreshToken = "test-refresh-token"
 
 	Convey("GetRefreshToken", t, func() {
 		Convey("returns cookie value if value is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: refreshCookieKey, Value: testRefreshToken})
 			cookie, _ := GetRefreshToken(req)
 			So(cookie, ShouldEqual, testRefreshToken)
 		})
 
 		Convey("returns error if no cookie is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			_, err := GetRefreshToken(req)
 			So(err, ShouldNotBeNil)
 		})

--- a/cookies/usertoken_test.go
+++ b/cookies/usertoken_test.go
@@ -10,20 +10,19 @@ import (
 )
 
 func TestUnitUserToken(t *testing.T) {
-
 	var testDomain = "www.test.com"
 	var testAccessToken = "test-access-token"
 
 	Convey("GetUserAuthToken", t, func() {
 		Convey("returns cookie value if value is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			req.AddCookie(&http.Cookie{Name: florenceCookieKey, Value: testAccessToken})
 			cookie, _ := GetUserAuthToken(req)
 			So(cookie, ShouldEqual, testAccessToken)
 		})
 
 		Convey("returns error if no cookie is set", func() {
-			req := httptest.NewRequest("GET", "/", nil)
+			req := httptest.NewRequest("GET", "/", http.NoBody)
 			_, err := GetUserAuthToken(req)
 			So(err, ShouldNotBeNil)
 		})

--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@ func main() {
 	var domain = "localhost"
 	http.HandleFunc("/set-cookies", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("Setting all cookies")
-		cookies.SetPolicy(w, policy, domain)
-		cookies.SetPreferenceIsSet(w, domain)
+		cookies.SetPolicy(w, policy, domain)  //nolint:staticcheck // To be removed in future iteration
+		cookies.SetPreferenceIsSet(w, domain) //nolint:staticcheck // To be removed in future iteration
 		cookies.SetLang(w, "en", domain)
 		cookies.SetCollection(w, "test-collection-id-123456789", domain)
 		cookies.SetUserAuthToken(w, "test-user-auth-token", domain)
@@ -25,33 +25,55 @@ func main() {
 
 	http.HandleFunc("/cookies", func(w http.ResponseWriter, r *http.Request) {
 		cookiesResponse := cookies.GetCookiePreferences(r)
-		w.Write([]byte(fmt.Sprintf("%+v \n", cookiesResponse)))
+		_, err := fmt.Fprintf(w, "%+v \n", cookiesResponse)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 
 	http.HandleFunc("/lang", func(w http.ResponseWriter, r *http.Request) {
 		cookiesResponse, err := cookies.GetLang(r)
 		if err != nil {
-			w.Write([]byte(err.Error()))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
-		w.Write([]byte(fmt.Sprintf("%+v \n", cookiesResponse)))
+
+		_, wErr := fmt.Fprintf(w, "%+v \n", cookiesResponse)
+		if wErr != nil {
+			http.Error(w, wErr.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 
 	http.HandleFunc("/collection", func(w http.ResponseWriter, r *http.Request) {
 		cookiesResponse, err := cookies.GetCollection(r)
 		if err != nil {
-			w.Write([]byte(err.Error()))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
-		w.Write([]byte(fmt.Sprintf("%+v \n", cookiesResponse)))
+
+		_, wErr := fmt.Fprintf(w, "%+v \n", cookiesResponse)
+		if wErr != nil {
+			http.Error(w, wErr.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 
 	http.HandleFunc("/user-auth-token", func(w http.ResponseWriter, r *http.Request) {
 		cookiesResponse, err := cookies.GetUserAuthToken(r)
 		if err != nil {
-			w.Write([]byte(err.Error()))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
-		w.Write([]byte(fmt.Sprintf("%+v \n", cookiesResponse)))
+
+		_, wErr := fmt.Fprintf(w, "%+v \n", cookiesResponse)
+		if wErr != nil {
+			http.Error(w, wErr.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 
 	fmt.Println("Running on port 22888")
-	http.ListenAndServe(":22888", nil)
+	http.ListenAndServe(":22888", nil) //nolint:all // local dev server
 }

--- a/main.go
+++ b/main.go
@@ -12,12 +12,21 @@ var policy = cookies.Policy{
 	Usage:     true,
 }
 
+var ONSPolicy = cookies.ONSPolicy{
+	Essential: true,
+	Settings:  true,
+	Usage:     true,
+	Campaigns: true,
+}
+
 func main() {
 	var domain = "localhost"
 	http.HandleFunc("/set-cookies", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("Setting all cookies")
-		cookies.SetPolicy(w, policy, domain)  //nolint:staticcheck // To be removed in future iteration
+		cookies.SetPolicy(w, policy, domain) //nolint:staticcheck // To be removed in future iteration
+		cookies.SetONSPolicy(w, ONSPolicy, domain)
 		cookies.SetPreferenceIsSet(w, domain) //nolint:staticcheck // To be removed in future iteration
+		cookies.SetONSPreferenceIsSet(w, domain)
 		cookies.SetLang(w, "en", domain)
 		cookies.SetCollection(w, "test-collection-id-123456789", domain)
 		cookies.SetUserAuthToken(w, "test-user-auth-token", domain)
@@ -25,9 +34,17 @@ func main() {
 
 	http.HandleFunc("/cookies", func(w http.ResponseWriter, r *http.Request) {
 		cookiesResponse := cookies.GetCookiePreferences(r)
+		onsCookiesResponse := cookies.GetONSCookiePreferences(r)
+
 		_, err := fmt.Fprintf(w, "%+v \n", cookiesResponse)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		_, wErr := fmt.Fprintf(w, "%+v \n", onsCookiesResponse)
+		if wErr != nil {
+			http.Error(w, wErr.Error(), http.StatusInternalServerError)
 			return
 		}
 	})


### PR DESCRIPTION
### What

- Added new cookies `ons_cookie_policy` and `ons_cookie_message_displayed` keys and values
- Marked legacy cookies and functions as deprecated
- Created new functions to handle setting and reading cookies so that dual running can be achieved 
- Lots of tests!
AKA ✅ [Add new cookies to dp-cookies](https://jira.ons.gov.uk/browse/DIS-2553)

### How to review

- Sense check
- Tests pass
- Media review
- _Optionally_ 
  - pull this branch
  - point to your local version of `dp-cookies` in the `dp-frontend-cookie-controller`
  - add the below snippet to the edit handler of the cookie controller 
  - run the frontend cookie controller and `dp-design-system`
  - edit your cookie preferences and checkout your cookies 🍪!

```go
        newCp := cookies.ONSPolicy{
		Essential: true,
		Settings:  false,
		Usage:     usage,
		Campaigns: false,
	}
	cookies.SetONSPreferenceIsSet(w, siteDomain)
	cookies.SetONSPolicy(w, newCp, siteDomain)
```

https://github.com/user-attachments/assets/51737bb3-aef5-48f8-87a1-3160a6ded623

### Who can review

Frontend go dev
